### PR TITLE
Fix: ChatBox Mention force above Cursor

### DIFF
--- a/front/components/ChatBox/index.tsx
+++ b/front/components/ChatBox/index.tsx
@@ -63,7 +63,7 @@ const ChatBox: FC<Props> = ({ onSubmitForm, chat, onChangeChat, placeholder, dat
           onKeyPress={onKeydownChat}
           placeholder={placeholder}
           inputRef={textareaRef}
-          allowSuggestionsAboveCursor
+          forceSuggestionsAboveCursor
         >
           <Mention
             appendSpaceOnAdd


### PR DESCRIPTION
react-mention 사용 과정에서 워크스페이스 사용자 추천을 항상 커서 위로 나오게 수정


allowSuggestionsAboveCursor: Renders the SuggestionList above the cursor if there is not enough space below

forceSuggestionsAboveCursor: Forces the SuggestionList to be rendered above the cursor